### PR TITLE
Fix packaging (#3, a51baad) for real at last

### DIFF
--- a/graddfril/__init__.py
+++ b/graddfril/__init__.py
@@ -1,0 +1,2 @@
+from pkg_resources import declare_namespace
+declare_namespace(__name__)

--- a/graddfril/desktop/__init__.py
+++ b/graddfril/desktop/__init__.py
@@ -1,0 +1,2 @@
+from pkg_resources import declare_namespace
+declare_namespace(__name__)


### PR DESCRIPTION
As in this package can now be installed with pip and then imported via `import graddfril.desktop.grabber_aggregator_refimpl`.
For some reason, explicit namespace declaration in **init**.py seems necessary; might be a bug in pbr.
